### PR TITLE
Fix segmentation fault

### DIFF
--- a/stbridge.h
+++ b/stbridge.h
@@ -86,8 +86,8 @@ public:
 private:
     Device(std::string sn, std::shared_ptr<Brg> brg, std::shared_ptr<STLinkInterface> stlink);
 
-    std::shared_ptr<Brg> brg;
     std::shared_ptr<STLinkInterface> stlink;
+    std::shared_ptr<Brg> brg;
 
     std::string sn;
     Brg_CanInitT can_params;


### PR DESCRIPTION
Device holds a shared smart pointer to Brg named `brg` and a shared smart pointer to STLinkInterface named `stlink`. However, the `brg` member will end up with a raw pointer to the `stlink` as well. Since the order in which C++ calls class member destructors is in the reverse order in which they appear in the class definition, `stlink`'s destructor will be called first, and then `brg`'s descructor will be called. This leaves `brg` with a dangling pointer that can lead to a segmentation fault. The solution is to define `stlink` before `brg` in the Device class definition.