### PR TITLE
Linux: USBInterface::get_device() fails when using exclusive access.

### DIFF
--- a/src/stbridge.cpp
+++ b/src/stbridge.cpp
@@ -360,6 +360,7 @@ Device USBInterface::get_device(std::string sn) {
     }
 
     auto brg = std::make_shared<Brg>(*stlink);
+    brg->SetOpenModeExclusive(false);
     check_error(Brg::ConvSTLinkIfToBrgStatus(stlink->EnumDevices(NULL, false)));
     check_error(brg->OpenStlink(sn.c_str(), true));
 


### PR DESCRIPTION
When using multiple Python scripts, each controlling one ST-LINK, we encounter an error when using get_device(serial number).

dev = st.USBInterface.get_device("blanked_serial") RuntimeError: BRG_ERROR: 1

The provided example.py used a working function like dev = st.USBInterface.list_devices()[0]; the st.USBInterface.get_device(“serial”) failed. It turned out that the list_devices() function opens the device in nonexclusive mode, while the get_device() function opens it in exclusive mode. The function STLink_OpenDevice() in STLINK-V3-BRIDGE_libusb returns SS_CMD_NOT_AVAILABLE when exclusive access is requested. This feature is not supported yet and fails when requested.

Quick solution; request nonexclusive access until this feature is supported in STLINK-V3-BRIDGE_libusb.

Problem code:
https://github.com/dragonlock2/STLINK-V3-BRIDGE_libusb/blob/e937d3dc98095789f9e6f44387f0ac547575a9d9/src/common/stlink_interface.cpp#L214 STLinkInterface::STLink_OpenDevice(TEnumStlinkInterface IfId,
                                   uint8_t DevIdxInList,
                                   uint8_t bExclusiveAccess, void **pHandle)
{
    if (IfId != STLINK_BRIDGE) {
        return SS_DEVICE_NOT_SUPPORTED;
    }
    if (bExclusiveAccess != 0) {
        return SS_CMD_NOT_AVAILABLE;
    }